### PR TITLE
change autoloader to PSR-4 as the current setting is invalid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "PHPBenchTime\\": "src/"
         }
     }


### PR DESCRIPTION
When using the `Timer` class, the composer PSR-0 autoloader
looks for a file

`vendor/jsanc623/phpbenchtime/src/PHPBenchTime/Timer.php`

which doesn't exist: the acutal location is

`vendor/jsanc623/phpbenchtime/src/Timer.php`

I see two possible solutions:

1. move `Timer.php` into a subdirectory `PHPBenchTime`, or
2. change the autoloader type to *PSR-4*.

This pull request changes to autoloader type to *PSR-4*.